### PR TITLE
Fix dashboard avatar placeholder

### DIFF
--- a/src/app/(frontend)/dashboard/page.client.test.tsx
+++ b/src/app/(frontend)/dashboard/page.client.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+import { DashboardAvatar, getAvatarInitials } from './page.client'
+
+const testUser = {
+  id: 'user-123',
+  email: 'ada@example.com',
+  name: 'Ada Lovelace',
+  createdAt: '2026-01-02T00:00:00.000Z',
+}
+
+describe('Dashboard avatar placeholder', () => {
+  it('builds stable initials from a name, email, or empty profile', () => {
+    expect(getAvatarInitials('Ada Lovelace', 'ada@example.com')).toBe('AL')
+    expect(getAvatarInitials('Ada King Lovelace', 'ada@example.com')).toBe('AL')
+    expect(getAvatarInitials('', 'neighbor@example.com')).toBe('NE')
+    expect(getAvatarInitials(null, null)).toBe('NG')
+  })
+
+  it('renders an accessible initials avatar instead of a missing placeholder image', () => {
+    const markup = renderToStaticMarkup(<DashboardAvatar user={testUser as any} />)
+
+    expect(markup).toContain('role="img"')
+    expect(markup).toContain('aria-label="Ada Lovelace avatar placeholder"')
+    expect(markup).toContain('>AL</div>')
+    expect(markup).not.toContain('<img')
+    expect(markup).not.toContain('/api/placeholder/120/120')
+  })
+})

--- a/src/app/(frontend)/dashboard/page.client.tsx
+++ b/src/app/(frontend)/dashboard/page.client.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useEffect } from 'react'
 import Link from 'next/link'
-import Image from 'next/image'
 import type { User } from '@/payload-types'
 
 interface DashboardClientProps {
@@ -31,6 +30,34 @@ interface Event {
   description: string
   date: string
   location: string
+}
+
+export const getAvatarInitials = (name?: string | null, email?: string | null): string => {
+  const fallback = email?.split('@')[0]
+  const source = (name?.trim() || fallback?.trim() || '').trim()
+
+  if (!source) return 'NG'
+
+  const parts = source.split(/\s+/).filter(Boolean)
+  const firstPart = parts[0] ?? source
+  const lastPart = parts[parts.length - 1] ?? firstPart
+  const initials =
+    parts.length > 1
+      ? `${firstPart.charAt(0)}${lastPart.charAt(0)}`
+      : source.slice(0, 2)
+
+  return initials.toUpperCase()
+}
+
+export const DashboardAvatar: React.FC<{ user: Pick<User, 'name' | 'email'> }> = ({ user }) => {
+  const avatarInitials = getAvatarInitials(user.name, user.email)
+  const avatarLabel = `${user.name || user.email || 'NeighborGoods user'} avatar placeholder`
+
+  return (
+    <div className="avatar" role="img" aria-label={avatarLabel}>
+      {avatarInitials}
+    </div>
+  )
 }
 
 export const DashboardClient: React.FC<DashboardClientProps> = ({ user, showDeletedMessage }) => {
@@ -149,6 +176,8 @@ export const DashboardClient: React.FC<DashboardClientProps> = ({ user, showDele
     return formatDate(user.createdAt)
   }
 
+  const primaryAdminLibrary = adminLibraries[0]
+
   if (isLoading) {
     return (
       <main className="container">
@@ -173,8 +202,8 @@ export const DashboardClient: React.FC<DashboardClientProps> = ({ user, showDele
           <h1>User Dashboard</h1>
         </div>
         <div className="flex gap-2">
-          {adminLibraries.length > 0 && (
-            <Link href={`/libraries/${adminLibraries[0].id}/moderate`} className="btn btn-secondary">
+          {primaryAdminLibrary && (
+            <Link href={`/libraries/${primaryAdminLibrary.id}/moderate`} className="btn btn-secondary">
               Moderator Dashboard
             </Link>
           )}
@@ -187,9 +216,7 @@ export const DashboardClient: React.FC<DashboardClientProps> = ({ user, showDele
       {/* Profile Header */}
       <div className="card">
         <div className="profile-top">
-          <div className="avatar">
-            <Image src="/api/placeholder/120/120" alt="User Avatar" width={120} height={120} />
-          </div>
+          <DashboardAvatar user={user} />
           <div className="profile-name-section">
             <h1 className="profile-name">{user.name}</h1>
             <p>Member since {getJoinedDate()} • NeighborGoods</p>

--- a/src/app/(frontend)/globals.css
+++ b/src/app/(frontend)/globals.css
@@ -359,10 +359,25 @@
     gap: 16px;
   }
 
-  .avatar img {
+  .avatar {
     width: 120px;
     height: 120px;
+    flex: 0 0 120px;
     border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    background-color: var(--dark-green);
+    color: var(--lighter-green);
+    font-size: 36px;
+    font-weight: 700;
+    letter-spacing: 0;
+  }
+
+  .avatar img {
+    width: 100%;
+    height: 100%;
     object-fit: cover;
   }
 


### PR DESCRIPTION
## Summary
- Replace the missing `/api/placeholder/120/120` dashboard avatar image with a local initials-based placeholder.
- Keep the avatar in a fixed 120x120 circular frame so it does not collapse or crop awkwardly.
- Add unit coverage for initials generation and for avoiding the missing placeholder image.

Closes #94

## Validation
- `npx -y yarn@1.22.22 install --frozen-lockfile`
- `npx -y yarn@1.22.22 test:unit --run 'src/app/(frontend)/dashboard/page.client.test.tsx'`
- `git diff --check`
- `npx -y tsc --noEmit --pretty false --incremental false` still reports existing project errors outside `dashboard/page.client`; no dashboard-related type errors were found.